### PR TITLE
Add terminal output format

### DIFF
--- a/rapids-build-metrics-reporter.py
+++ b/rapids-build-metrics-reporter.py
@@ -15,7 +15,7 @@ parser.add_argument(
 parser.add_argument(
     "--fmt",
     type=str,
-    default="csv",
+    default="terminal",
     choices=["csv", "xml", "html", "terminal"],
     help="output format (to stdout)",
 )


### PR DESCRIPTION
Thanks for building this! 

This PR adds an output format that is more readable for interactive terminal use. 

I have made this the default output format (in a separate commit). I can imagine that this is a backwards incompatible change. So I am open to revert that. 


Example output: 

```
$ python ~/projects/raft-build-metrics-reporter/rapids-build-metrics-reporter.py   --cmp_log ~/projects/raft-add-ivf-flat-scan-spec/cpp/build/{current,split}.ninja_log
 822.1s                    0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_interleaved_scan_uint8_t_int64_t.cu.o
 802.8s                    0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_interleaved_scan_int8_t_int64_t.cu.o
 545.4s                    0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_interleaved_scan_float_int64_t.cu.o
  54.3s -762.8s -93.4%     0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_uint8_t_int64_t.cu.o
  54.2s -730.8s -93.1%     0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_int8_t_int64_t.cu.o
  54.0s -464.9s -89.6%     0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_float_int64_t.cu.o
   3.7s                    0K  build.ninja

$ python ~/projects/raft-build-metrics-reporter/rapids-build-metrics-reporter.py  ~/projects/raft-add-ivf-flat-scan-spec/cpp/build/current.ninja_log
 817.2s     0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_uint8_t_int64_t.cu.o
 785.0s     0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_int8_t_int64_t.cu.o
 518.9s     0K  CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_float_int64_t.cu.o
```