### PR TITLE
Add kernel template instantiation reporter

### DIFF
--- a/rapids-template-instantiation-reporter.py
+++ b/rapids-template-instantiation-reporter.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+from subprocess import PIPE
+import shutil
+from collections import Counter
+from pathlib import Path
+
+
+def log(msg, verbose=True):
+    if verbose:
+        print(msg)
+
+
+def run(*args, **kwargs):
+    return subprocess.run(list(args), check=True, **kwargs)
+
+
+def progress(iterable, display=True):
+    if display:
+        print()
+    for i, it in enumerate(iterable):
+        if display:
+            print(f"\rProgress: {i}", end="", flush=True)
+        yield it
+    if display:
+        print()
+
+
+def extract_template(line):
+    # Example line:
+    #  Function void raft::random::detail::rmat_gen_kernel<long, double>(T1 *, T1 *, T1 *, const T2 *, T1, T1, T1, T1, raft::random::RngState):
+    line = line.replace("Function", "").replace("void", "").strip()
+    if "<" in line:
+        line = line.split("<")[0]
+    # Example return: raft::random::detail::rmat_gen_kernel
+    return line
+
+
+def get_kernels(cuobjdump, cu_filt, grep, object_file_path):
+    # Executes:
+    # > cuobjdump -res-usage file | cu++filt | grep Function
+    step1 = run(cuobjdump, "-res-usage", object_file_path, stdout=PIPE)
+    step2 = run(cu_filt, input=step1.stdout, stdout=PIPE)
+    step3 = run(grep, "Function", input=step2.stdout, stdout=PIPE)
+
+    out_str = step3.stdout.decode(encoding="utf-8", errors="strict")
+
+    return [extract_template(line) for line in out_str.splitlines()]
+
+
+def get_object_files(ninja, build_dir, target):
+    # Executes:
+    # > ninja -C build/dir -t input <target>
+    build_dir = Path(build_dir)
+    out = run(ninja, "-C", build_dir, "-t", "inputs", target, stdout=PIPE)
+    out_str = out.stdout.decode(encoding="utf-8", errors="strict")
+    return [
+        str(build_dir / line.strip())
+        for line in out_str.splitlines()
+        if line.endswith(".o")
+    ]
+
+
+def main(
+    build_dir, target, top_n, summary_only=True, display_progress=True, verbose=True
+):
+    # Check that we have the right binaries in the environment.
+    binary_names = ["ninja", "grep", "cuobjdump", "cu++filt"]
+    binaries = list(map(shutil.which, binary_names))
+    ninja, grep, cuobjdump, cu_filt = binaries
+
+    fail_on_bins = any(b is None for b in binaries)
+    if fail_on_bins:
+        for path, name in zip(binaries, binary_names):
+            if path is None:
+                print(f"Could not find {name}. Make sure {name} is in PATH.")
+        exit(1)
+
+    for path, name in zip(binaries, binary_names):
+        log(f"Found {name}: {path}", verbose=verbose)
+
+    # Get object files from target:
+    object_files = get_object_files(ninja, build_dir, target)
+
+    # Compute the counts of each object-kernel combination
+    get_kernel_bins = (cuobjdump, cu_filt, grep)
+    obj_kernel_tuples = (
+        (obj, kernel)
+        for obj in object_files
+        for kernel in get_kernels(*get_kernel_bins, obj)
+    )
+    obj_kernel_counts = Counter(
+        tup for tup in progress(obj_kernel_tuples, display=display_progress)
+    )
+
+    # Create an index with the kernel counts per object and the object count per kernel:
+    obj2kernel = dict()
+    kernel2obj = dict()
+    kernel_counts = Counter()
+    obj_counts = Counter()
+
+    for (obj, kernel), count in obj_kernel_counts.items():
+        # Update the obj2kernel and kernel2obj index:
+        obj2kernel_ctr = obj2kernel.setdefault(obj, Counter())
+        kernel2obj_ctr = kernel2obj.setdefault(kernel, Counter())
+        obj2kernel_ctr += Counter({kernel: count})
+        kernel2obj_ctr += Counter({obj: count})
+
+        # Update counters:
+        kernel_counts += Counter({kernel: count})
+        obj_counts += Counter({obj: count})
+
+    # Print summary statistics
+    print("\nObjects with most kernels")
+    print("=========================\n")
+    for obj, total_count in obj_counts.most_common()[:top_n]:
+        print(
+            f"{total_count:4d} kernel instances in {obj} ({len(obj2kernel[obj])} kernel templates)"
+        )
+
+    print("\nKernels with most instances")
+    print("===========================\n")
+    for kernel, total_count in kernel_counts.most_common()[:top_n]:
+        print(
+            f"{total_count:4d} instances of {kernel} in {len(kernel2obj[kernel])} objects."
+        )
+
+    if summary_only:
+        return
+
+    print("\nDetails: Objects")
+    print("================\n")
+    for obj, total_count in obj_counts.most_common()[:top_n]:
+        print(
+            f"{total_count:4d} kernel instances in {obj} across {len(obj2kernel[obj])} templates:"
+        )
+        for kernel, c in obj2kernel[obj].most_common():
+            print(f"    {c:4d}: {kernel}")
+        print()
+
+    print("\nDetails: Kernels")
+    print("================\n")
+    for kernel, total_count in kernel_counts.most_common()[:top_n]:
+        print(
+            f"\n{total_count:4d} instances of {kernel} in {len(kernel2obj[kernel])} objects:"
+        )
+        for obj, c in kernel2obj[kernel].most_common():
+            print(f"    {c:4d}: {obj}")
+        print()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target", type=str, help="The ninja target to investigate")
+    parser.add_argument(
+        "--build-dir",
+        type=str,
+        default="./",
+        help="Build directory",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=None,
+        help="Log only top N most common objects/kernels",
+    )
+
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Show a summary of statistics, but no details.",
+    )
+    parser.set_defaults(summary=False)
+
+    parser.add_argument(
+        "--no-progress", action="store_true", help="Do not show progress indication"
+    )
+    parser.set_defaults(no_progress=False)
+    parser.add_argument("--verbose", action="store_true")
+    parser.set_defaults(verbose=False)
+
+    args = parser.parse_args()
+
+    main(
+        args.build_dir,
+        args.target,
+        args.top_n,
+        summary_only=args.summary,
+        display_progress=not args.no_progress,
+        verbose=args.verbose,
+    )

--- a/rapids-template-instantiation-reporter.py
+++ b/rapids-template-instantiation-reporter.py
@@ -39,16 +39,19 @@ def extract_template(line):
 
 
 def get_kernels(cuobjdump, cu_filt, grep, object_file_path):
-    # Executes:
-    # > cuobjdump -res-usage file | cu++filt | grep Function
-    step1 = run(cuobjdump, "-res-usage", object_file_path, stdout=PIPE)
-    step2 = run(cu_filt, input=step1.stdout, stdout=PIPE)
-    step3 = run(grep, "Function", input=step2.stdout, stdout=PIPE)
+    try:
+        # Executes:
+        # > cuobjdump -res-usage file | cu++filt | grep Function
+        step1 = run(cuobjdump, "-res-usage", object_file_path, stdout=PIPE)
+        step2 = run(cu_filt, input=step1.stdout, stdout=PIPE)
+        step3 = run(grep, "Function", input=step2.stdout, stdout=PIPE)
 
-    out_str = step3.stdout.decode(encoding="utf-8", errors="strict")
+        out_str = step3.stdout.decode(encoding="utf-8", errors="strict")
 
-    return [extract_template(line) for line in out_str.splitlines()]
-
+        return [extract_template(line) for line in out_str.splitlines()]
+    except Exception as e:
+        print(e)
+        return []
 
 def get_object_files(ninja, build_dir, target):
     # Executes:


### PR DESCRIPTION
This PR adds the kernel template instantiation reporter. It reports on objects that instantiate many kernel template and kernel templates that get instantiated in many object files. 

It takes a ninja target and looks at all object files that are inputs, i.e.: 
``` bash 
ninja -t input <targets>
```
For each of these object files, it collects all kernel templates:
```bash 
cuobjdump -res-usage | cu++filt | grep Function | sed 's/<*//'
```
Then it looks which object instantiates many templates and which kernel template is instantiates in many objects. It can provide a summary view (shown below) or a detailed view outlining each template instantiated in each object and vice versa. To limit results, there is a `--top-n` flag. For interactive use, the program shows a progress indicator (it can take ~10 seconds to get the stats for libraft.so). This progress indicator can also be turned off (with `--no-progress`). 

Example output
============
``` bash
$ python rapids-template-instantiation-reporter.py --build-dir ~/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/ --top-n 10 --skip-details  libraft.so
```
```
Objects with most kernels
=========================

 408 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_int8_t_int64_t.cu.o (16 kernel templates)
 408 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_uint8_t_int64_t.cu.o (16 kernel templates)
 391 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfpq_build_int8_t_int64_t.cu.o (42 kernel templates)
 391 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfpq_build_uint8_t_int64_t.cu.o (42 kernel templates)
 381 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfpq_build_float_int64_t.cu.o (41 kernel templates)
 301 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_build_int8_t_int64_t.cu.o (30 kernel templates)
 301 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_build_uint8_t_int64_t.cu.o (30 kernel templates)
 297 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_search_float_int64_t.cu.o (16 kernel templates)
 295 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/ivfflat_build_float_int64_t.cu.o (30 kernel templates)
 266 kernel instances in /home/ahendriksen/projects/raft-add-ivf-flat-scan-spec/cpp/build-backup/CMakeFiles/raft_lib.dir/src/neighbors/specializations/detail/brute_force_knn_impl_uint_float_int.cu.o (19 kernel templates)

Kernels with most instances
===========================

2858 instances of raft::linalg::detail::coalescedReductionThinKernel in 84 objects. 2481 instances of raft::linalg::detail::map_kernel in 84 objects. 1103 instances of raft::matrix::detail::matrixLinewiseVecColsMainKernel in 82 objects. 1103 instances of raft::matrix::detail::matrixLinewiseVecRowsMainKernel in 82 objects.
 952 instances of raft::linalg::detail::coalescedReductionThickKernel in 84 objects.
 945 instances of raft::neighbors::ivf_pq::detail::compute_similarity_kernel in 21 objects.
 702 instances of raft::neighbors::ivf_flat::detail::interleaved_scan_kernel in 3 objects.
 518 instances of raft::linalg::detail::coalescedReductionMediumKernel in 84 objects.
 492 instances of raft::neighbors::ivf_pq::detail::calc_chunk_indices_kernel in 82 objects.
 369 instances of raft::matrix::detail::matrixLinewiseVecColsTailKernel in 82 objects.
```